### PR TITLE
Implement provider registry with lazy loading and fallback

### DIFF
--- a/codex/roadmap.yaml
+++ b/codex/roadmap.yaml
@@ -41,6 +41,7 @@ tasks:
     dependencies: []
     labels: ["DI","models","testable"]
     estimate: "2d"
+    status: completed
 
   - id: A6
     area: architecture
@@ -115,6 +116,7 @@ tasks:
     dependencies: ["A1"]
     labels: ["DI","resilience","extensibility"]
     estimate: "1.5d"
+    status: completed
 
   - id: A3
     area: architecture

--- a/server/app/search/providers/__init__.py
+++ b/server/app/search/providers/__init__.py
@@ -1,13 +1,27 @@
-"""Provider interfaces for search components."""
+"""Provider interfaces and registry helpers for search components."""
 
-from .embedding import EmbeddingProvider, HFEmbeddingProvider, build_embedding_provider
-from .reranker import CrossEncoderProvider, HFCrossEncoderProvider, build_reranker_provider
+from .embedding import (
+    EmbeddingProvider,
+    HFEmbeddingProvider,
+    build_embedding_provider,
+    register_embedding_provider,
+)
+from .reranker import (
+    CrossEncoderProvider,
+    HFCrossEncoderProvider,
+    build_reranker_provider,
+    register_reranker_provider,
+)
+from .registry import ProviderRegistry
 
 __all__ = [
     "EmbeddingProvider",
     "HFEmbeddingProvider",
     "build_embedding_provider",
+    "register_embedding_provider",
     "CrossEncoderProvider",
     "HFCrossEncoderProvider",
     "build_reranker_provider",
+    "register_reranker_provider",
+    "ProviderRegistry",
 ]

--- a/server/app/search/providers/registry.py
+++ b/server/app/search/providers/registry.py
@@ -1,0 +1,87 @@
+"""Utilities for registering and resolving model providers."""
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from typing import Dict, Generic, Optional, Tuple, TypeVar
+
+P = TypeVar("P")
+
+
+class ProviderRegistry(Generic[P]):
+    """Simple registry that supports aliases and fallback resolution."""
+
+    def __init__(self, default_key: str):
+        if not default_key or not default_key.strip():
+            raise ValueError("default_key must be a non-empty string")
+        self._default_key = default_key.strip().lower()
+        self._factories: Dict[str, Callable[..., P]] = {}
+        self._canonical_keys: Dict[str, str] = {}
+
+    @property
+    def default_key(self) -> str:
+        """Return the canonical default provider key."""
+
+        return self._default_key
+
+    def register(
+        self,
+        key: str,
+        *,
+        aliases: Sequence[str] | None = None,
+    ) -> Callable[[Callable[..., P]], Callable[..., P]]:
+        """Register a factory under the provided key and optional aliases."""
+
+        canonical = self._normalize(key)
+        normalized_keys = {canonical}
+        if aliases:
+            normalized_keys.update(self._normalize(alias) for alias in aliases)
+
+        def decorator(factory: Callable[..., P]) -> Callable[..., P]:
+            for normalized in normalized_keys:
+                self._factories[normalized] = factory
+                self._canonical_keys[normalized] = canonical
+            return factory
+
+        return decorator
+
+    def create(self, key: str | None, *args, **kwargs) -> Tuple[P, str, Optional[str]]:
+        """Instantiate a provider, returning metadata for fallback handling.
+
+        Returns a tuple of ``(instance, resolved_key, fallback_from)`` where
+        ``resolved_key`` is the canonical key that produced the provider and
+        ``fallback_from`` is the originally requested key if a fallback was
+        required (``None`` otherwise).
+        """
+
+        requested = self._normalize(key)
+        lookup_key = requested or self._default_key
+        factory = self._factories.get(lookup_key)
+        fallback_from: str | None = None
+
+        if factory is None:
+            fallback_from = lookup_key
+            factory = self._factories.get(self._default_key)
+            lookup_key = self._default_key
+            if factory is None:
+                raise ValueError(
+                    f"Default provider '{self._default_key}' is not registered"
+                )
+
+        instance = factory(*args, **kwargs)
+        resolved_key = self._canonical_keys.get(lookup_key, lookup_key)
+        # If we fell back because the requested key was empty, suppress the
+        # fallback marker so callers don't treat the default as an error.
+        if fallback_from == self._default_key and requested is None:
+            fallback_from = None
+        return (
+            instance,
+            resolved_key,
+            fallback_from if requested else fallback_from,
+        )
+
+    @staticmethod
+    def _normalize(key: str | None) -> Optional[str]:
+        if key is None:
+            return None
+        normalized = key.strip().lower()
+        return normalized or None

--- a/server/app/search/providers/reranker.py
+++ b/server/app/search/providers/reranker.py
@@ -2,9 +2,12 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Sequence
+from threading import Lock
+from typing import Callable, Sequence, Tuple
 
 from sentence_transformers import CrossEncoder
+
+from .registry import ProviderRegistry
 
 
 class CrossEncoderProvider(ABC):
@@ -18,21 +21,60 @@ class CrossEncoderProvider(ABC):
 class HFCrossEncoderProvider(CrossEncoderProvider):
     """Cross-encoder provider backed by Hugging Face models."""
 
-    def __init__(self, model_name: str):
-        self._model = CrossEncoder(model_name)
+    def __init__(
+        self,
+        model_name: str,
+        loader: Callable[[str], CrossEncoder] | None = None,
+    ) -> None:
+        self._model_name = model_name
+        self._loader = loader or CrossEncoder
+        self._model: CrossEncoder | None = None
+        self._lock = Lock()
+
+    def _get_model(self) -> CrossEncoder:
+        if self._model is None:
+            with self._lock:
+                if self._model is None:
+                    self._model = self._loader(self._model_name)
+        return self._model
 
     def rerank(self, query: str, passages: Sequence[str]) -> Sequence[float]:
         pairs = [(query, passage) for passage in passages]
-        scores = self._model.predict(pairs)
+        model = self._get_model()
+        scores = model.predict(pairs)
         if hasattr(scores, "tolist"):
             return scores.tolist()
         return list(scores)
 
 
-def build_reranker_provider(provider: str | None, model_name: str) -> CrossEncoderProvider:
-    """Factory for reranker providers."""
+_reranker_registry: ProviderRegistry[CrossEncoderProvider] = ProviderRegistry("huggingface")
 
-    provider_key = (provider or "huggingface").strip().lower()
-    if provider_key in {"hf", "huggingface", "cross-encoder"}:
-        return HFCrossEncoderProvider(model_name)
-    raise ValueError(f"Unsupported reranker provider: {provider}")
+
+def register_reranker_provider(
+    key: str,
+    *,
+    aliases: Sequence[str] | None = None,
+):
+    """Public decorator for registering reranker providers."""
+
+    return _reranker_registry.register(key, aliases=aliases)
+
+
+@register_reranker_provider(
+    "huggingface",
+    aliases=("hf", "cross-encoder"),
+)
+def _build_hf_reranker_provider(model_name: str) -> CrossEncoderProvider:
+    return HFCrossEncoderProvider(model_name)
+
+
+def build_reranker_provider(
+    provider: str | None,
+    model_name: str,
+) -> Tuple[CrossEncoderProvider, str, str | None]:
+    """Factory for reranker providers.
+
+    Returns a tuple of ``(provider, resolved_key, fallback_from)``.
+    """
+
+    return _reranker_registry.create(provider, model_name)

--- a/tests/unit/test_providers.py
+++ b/tests/unit/test_providers.py
@@ -1,5 +1,6 @@
 import pathlib
 import sys
+from typing import Sequence
 
 import pytest
 
@@ -7,16 +8,25 @@ sys.path.append(str(pathlib.Path(__file__).resolve().parents[2] / "server"))
 
 from app.search.providers import embedding as embedding_module
 from app.search.providers import reranker as reranker_module
-from app.search.providers.embedding import EmbeddingProvider, build_embedding_provider
+from app.search.providers.embedding import (
+    EmbeddingProvider,
+    HFEmbeddingProvider,
+    build_embedding_provider,
+    register_embedding_provider,
+)
 from app.search.providers.reranker import (
     CrossEncoderProvider,
+    HFCrossEncoderProvider,
     build_reranker_provider,
 )
 from app.search.reranker import CrossEncoderReranker
 
 
 class DummySentenceTransformer:
+    created_models: list[str] = []
+
     def __init__(self, model_name: str):
+        type(self).created_models.append(model_name)
         self.model_name = model_name
         self.calls: list[tuple[list[str], bool]] = []
 
@@ -27,13 +37,26 @@ class DummySentenceTransformer:
 
 
 class DummyCrossEncoder:
+    created_models: list[str] = []
+
     def __init__(self, model_name: str):
+        type(self).created_models.append(model_name)
         self.model_name = model_name
         self.calls: list[list[tuple[str, str]]] = []
 
     def predict(self, pairs):
         self.calls.append(list(pairs))
         return [float(len(q) + len(p)) for q, p in pairs]
+
+
+class DummyEmbeddingProvider(EmbeddingProvider):
+    def __init__(self):
+        self.payloads: list[Sequence[str]] = []
+
+    def encode(self, texts, *, normalize_embeddings: bool = True):
+        batch = list(texts if isinstance(texts, (list, tuple)) else [texts])
+        self.payloads.append(tuple(batch))
+        return [[42.0] for _ in batch]
 
 
 class DummyProvider(CrossEncoderProvider):
@@ -45,32 +68,76 @@ class DummyProvider(CrossEncoderProvider):
         return [42.0 for _ in passages]
 
 
+@pytest.fixture(autouse=True)
+def reset_dummy_state():
+    DummySentenceTransformer.created_models = []
+    DummyCrossEncoder.created_models = []
+    yield
+
+
 def test_build_embedding_provider_hf(monkeypatch):
     monkeypatch.setattr(embedding_module, "SentenceTransformer", DummySentenceTransformer)
-    provider = build_embedding_provider("huggingface", "dummy-model")
+    provider, resolved_key, fallback_from = build_embedding_provider("huggingface", "dummy-model")
+
+    assert isinstance(provider, HFEmbeddingProvider)
+    assert resolved_key == "huggingface"
+    assert fallback_from is None
+    assert DummySentenceTransformer.created_models == []
 
     vectors = provider.encode(["hello", "world"], normalize_embeddings=False)
 
-    assert isinstance(provider, EmbeddingProvider)
+    assert DummySentenceTransformer.created_models == ["dummy-model"]
     assert vectors[0][0] == 5.0
     assert vectors[1][0] == 5.0
 
 
-def test_build_embedding_provider_unsupported():
-    with pytest.raises(ValueError):
-        build_embedding_provider("unsupported", "model")
+def test_build_embedding_provider_fallback(monkeypatch):
+    monkeypatch.setattr(embedding_module, "SentenceTransformer", DummySentenceTransformer)
+    provider, resolved_key, fallback_from = build_embedding_provider("unsupported", "model")
+
+    assert resolved_key == "huggingface"
+    assert fallback_from == "unsupported"
+    assert provider.encode("x")[0][0] == 1.0
+
+
+def test_register_custom_embedding_provider():
+    @register_embedding_provider("dummy-test", aliases=("custom",))
+    def _factory(model_name: str) -> EmbeddingProvider:  # noqa: ARG001 - contract requires signature
+        return DummyEmbeddingProvider()
+
+    provider, resolved_key, fallback_from = build_embedding_provider("custom", "unused")
+
+    assert isinstance(provider, DummyEmbeddingProvider)
+    assert resolved_key == "dummy-test"
+    assert fallback_from is None
+    assert provider.encode(["a"])[0][0] == 42.0
 
 
 def test_build_reranker_provider_hf(monkeypatch):
     monkeypatch.setattr(reranker_module, "CrossEncoder", DummyCrossEncoder)
-    provider = build_reranker_provider("hf", "dummy-cross-encoder")
+    provider, resolved_key, fallback_from = build_reranker_provider("hf", "dummy-cross-encoder")
+
+    assert isinstance(provider, HFCrossEncoderProvider)
+    assert resolved_key == "huggingface"
+    assert fallback_from is None
+    assert DummyCrossEncoder.created_models == []
 
     scores = provider.rerank("q", ["a", "bb"])
 
+    assert DummyCrossEncoder.created_models == ["dummy-cross-encoder"]
     assert list(scores) == [float(len("q") + 1), float(len("q") + 2)]
 
 
-def test_cross_encoder_reranker_delegates(monkeypatch):
+def test_reranker_provider_fallback(monkeypatch):
+    monkeypatch.setattr(reranker_module, "CrossEncoder", DummyCrossEncoder)
+    provider, resolved_key, fallback_from = build_reranker_provider("unknown", "dummy")
+
+    assert resolved_key == "huggingface"
+    assert fallback_from == "unknown"
+    assert list(provider.rerank("q", ["a"])) == [float(len("q") + 1)]
+
+
+def test_cross_encoder_reranker_delegates():
     provider = DummyProvider()
     reranker = CrossEncoderReranker(provider=provider)
 


### PR DESCRIPTION
## Summary
- add a registry for embedding and reranker providers that supports aliases, lazy loading, and fallback metadata
- update FastAPI bootstrap to warn on unknown provider keys and mark A1/A8 complete in the roadmap
- document the registry pattern and extend unit tests to cover fallback and custom registrations

## Testing
- pytest tests/unit/test_providers.py

------
https://chatgpt.com/codex/tasks/task_e_68dce7f87978832e9a6b82bf7846bb4a