### PR TITLE
Refactor FastAPI entrypoint into modular routers

### DIFF
--- a/codex/roadmap.yaml
+++ b/codex/roadmap.yaml
@@ -90,6 +90,7 @@ tasks:
     dependencies: ["A6"]
     labels: ["scaling","cache","limits"]
     estimate: "2d"
+    status: not_started
 
   - id: A8
     area: architecture
@@ -351,6 +352,7 @@ tasks:
     dependencies: ["A6"]
     labels: ["observability","metrics"]
     estimate: "1.5d"
+    status: not_started
 
   - id: O3
     area: operator
@@ -373,6 +375,7 @@ tasks:
     dependencies: []
     labels: ["backup","recovery"]
     estimate: "2d"
+    status: not_started
 
   - id: O4
     area: operator
@@ -393,6 +396,7 @@ tasks:
     dependencies: ["O2"]
     labels: ["cost","performance"]
     estimate: "1.5d"
+    status: not_started
 
   - id: O5
     area: operator
@@ -416,6 +420,7 @@ tasks:
     dependencies: ["A6"]
     labels: ["security","audit"]
     estimate: "4d"
+    status: not_started
 
   - id: O7
     area: operator
@@ -436,6 +441,7 @@ tasks:
     dependencies: ["O2"]
     labels: ["sre","reliability"]
     estimate: "1d"
+    status: not_started
 
   - id: O6
     area: operator
@@ -456,3 +462,28 @@ tasks:
     dependencies: ["O1","O2","A2","A3"]
     labels: ["devops","k8s"]
     estimate: "5d"
+    status: not_started
+
+  - id: A9
+    area: architecture
+    milestone: M1
+    priority: P2
+    type: refactor
+    title: "FastAPI 진입점 모듈화 및 글로벌 상태 정리"
+    objective: "`server/app/main.py`에 집중된 글로벌 캐시/레이트리밋 로직을 모듈로 분리해 Redis 도입과 테스트 작성이 쉬운 구조를 만든다."
+    rationale: "현재 FastAPI 앱 구성, 캐시, 레이트리밋, AB 테스트 로직이 하나의 파일에 얽혀 있어 재사용과 단위 테스트가 어렵다."
+    suggested_changes:
+      - "server/app/api/__init__.py 및 router 모듈 생성"
+      - "server/app/services/cache.py, rate_limit.py 등으로 상태ful 로직 이동"
+      - "tests/unit/ 하위에 모듈화된 서비스 테스트 추가"
+    steps:
+      - "Request/response 모델과 의존성 주입을 위해 FastAPI `APIRouter` 기반 구조 도입"
+      - "임시 전역 dict 대신 인터페이스화된 캐시/레이트리밋 어댑터 작성"
+      - "환경 변수 기반 설정을 `settings` 혹은 `config` 객체를 통해 주입"
+    acceptance:
+      - "주요 엔드포인트가 router 모듈로 분리되고 단위 테스트로 검증된다"
+      - "Redis 도입(A2)의 진입점에서 글로벌 변수를 직접 수정하지 않는다"
+    dependencies: ["A1","A8"]
+    labels: ["maintainability","refactor"]
+    estimate: "2d"
+    status: completed

--- a/docs/Design.md
+++ b/docs/Design.md
@@ -6,3 +6,4 @@
 - 필터: lang / dir_hint / exclude_tests
 - Incremental 인덱싱(blake3), tus 이어올리기
 - RBAC(x-api-key), rate-limit, 임베딩/검색 캐시, /v1/metrics, A/B bucket
+- FastAPI 진입점은 `app.api` 패키지의 라우터와 `app.services` 계층으로 모듈화되어 있으며, 라우터는 `AppContext`를 통해 캐시·레이트리밋·검색기 등을 주입 받아 테스트와 향후 Redis 교체가 용이하다.

--- a/server/app/api/__init__.py
+++ b/server/app/api/__init__.py
@@ -1,0 +1,14 @@
+"""API router aggregation."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from app.api.routes import feedback, index, metrics, search, tenant
+
+api_router = APIRouter()
+api_router.include_router(tenant.router)
+api_router.include_router(index.router)
+api_router.include_router(search.router)
+api_router.include_router(feedback.router)
+api_router.include_router(metrics.router)

--- a/server/app/api/context.py
+++ b/server/app/api/context.py
@@ -1,0 +1,27 @@
+"""Application context shared across routers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from app.index.opensearch_store import OSStore
+from app.index.qdrant_store import QdrantStore
+from app.search.hybrid_search import HybridSearch
+from app.search.reranker import CrossEncoderReranker
+from app.services.api_key import APIKeyValidator
+from app.services.cache import EmbeddingCache, SearchCache
+from app.services.metrics import StatsTracker
+from app.services.rate_limit import RateLimiter
+
+
+@dataclass
+class AppContext:
+    qdrant: QdrantStore
+    opensearch: OSStore
+    searcher: HybridSearch
+    reranker: CrossEncoderReranker
+    embedding_cache: EmbeddingCache
+    search_cache: SearchCache
+    rate_limiter: RateLimiter
+    api_keys: APIKeyValidator
+    stats: StatsTracker

--- a/server/app/api/deps.py
+++ b/server/app/api/deps.py
@@ -1,0 +1,15 @@
+"""Common FastAPI dependencies for routers."""
+
+from __future__ import annotations
+
+from fastapi import Depends, Request
+
+from app.api.context import AppContext
+
+
+def get_context(request: Request) -> AppContext:
+    return request.app.state.context  # type: ignore[attr-defined]
+
+
+def provide_context(context: AppContext = Depends(get_context)) -> AppContext:
+    return context

--- a/server/app/api/routes/feedback.py
+++ b/server/app/api/routes/feedback.py
@@ -1,0 +1,33 @@
+"""Feedback endpoints."""
+
+from __future__ import annotations
+
+import time
+
+from fastapi import APIRouter, Depends
+
+from app.api.context import AppContext
+from app.api.deps import provide_context
+from app.models.schemas import FeedbackRequest, FeedbackResponse
+from app.utils.jsonl import append_jsonl
+
+router = APIRouter(prefix="/v1")
+
+
+@router.post("/feedback", response_model=FeedbackResponse)
+async def feedback(
+    req: FeedbackRequest,
+    *,
+    context: AppContext = Depends(provide_context),
+) -> FeedbackResponse:
+    append_jsonl(
+        "/app/server/data/feedback_log.jsonl",
+        {
+            "search_id": req.search_id,
+            "clicked_chunk_id": req.clicked_chunk_id,
+            "grade": int(req.grade),
+            "timestamp": time.time(),
+        },
+    )
+    context.stats.increment_feedback()
+    return FeedbackResponse(status="ok")

--- a/server/app/api/routes/index.py
+++ b/server/app/api/routes/index.py
@@ -1,0 +1,140 @@
+"""Indexing-related endpoints."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends, Header
+from qdrant_client.http.models import PointStruct
+
+from app.api.deps import provide_context
+from app.api.context import AppContext
+from app.config import settings
+from app.models.schemas import UploadRequest
+from app.utils.s3_utils import get_object_text
+
+router = APIRouter(prefix="/v1")
+
+
+@router.post("/index/upload")
+async def upload(
+    req: UploadRequest,
+    *,
+    x_api_key: str | None = Header(default=None),
+    context: AppContext = Depends(provide_context),
+) -> dict[str, Any]:
+    tenant = req.chunks[0].tenant_id if req.chunks else "default"
+    context.api_keys.enforce(tenant, x_api_key)
+
+    points: list[PointStruct] = []
+    os_docs: list[dict[str, Any]] = []
+
+    for chunk in req.chunks:
+        payload = {
+            "chunk_id": chunk.chunk_id,
+            "repo_id": chunk.repo_id,
+            "path_tokens": chunk.path_tokens,
+            "line_start": chunk.line_start,
+            "line_end": chunk.line_end,
+            "lang": chunk.lang,
+        }
+        if chunk.rel_path is not None:
+            payload["rel_path"] = chunk.rel_path
+
+        if chunk.privacy_mode:
+            assert chunk.vector is not None, "privacy_mode=True면 vector 필요"
+            vector = chunk.vector
+        else:
+            assert chunk.text is not None, "privacy_mode=False면 text 필요"
+            vector = context.embedding_cache.encode(chunk.text)
+            if chunk.repo_id not in settings.privacy_repo_ids:
+                os_docs.append(
+                    {
+                        "chunk_id": chunk.chunk_id,
+                        "repo_id": chunk.repo_id,
+                        "path_tokens": chunk.path_tokens,
+                        "rel_path": chunk.rel_path or "",
+                        "lang": chunk.lang,
+                        "line_start": chunk.line_start,
+                        "line_end": chunk.line_end,
+                        "text": chunk.text,
+                    }
+                )
+
+        points.append(
+            PointStruct(
+                id=chunk.chunk_id,
+                vector=vector,
+                payload=payload,
+            )
+        )
+
+    if points:
+        context.qdrant.upsert_tenant(tenant, points)
+    if os_docs:
+        context.opensearch.bulk_upsert_tenant(tenant, os_docs)
+
+    context.stats.increment_index(len(req.chunks))
+
+    return {"status": "ok", "qdrant": len(points), "opensearch": len(os_docs)}
+
+
+@router.post("/index/commit_tus")
+async def commit_tus(
+    body: dict[str, Any],
+    *,
+    x_api_key: str | None = Header(default=None),
+    context: AppContext = Depends(provide_context),
+) -> dict[str, Any]:
+    tenant_id = body.get("tenant_id", "default")
+    context.api_keys.enforce(tenant_id, x_api_key)
+
+    repo_id = body.get("repo_id")
+    chunk = body.get("chunk", {})
+    tus_key = body.get("tus_key")
+    assert repo_id and chunk and tus_key, "invalid payload"
+
+    object_key = f"uploads/{tus_key}"
+    text = get_object_text(object_key)
+    vector = context.embedding_cache.encode(text)
+
+    payload = {
+        "chunk_id": chunk["chunk_id"],
+        "repo_id": repo_id,
+        "path_tokens": chunk["path_tokens"],
+        "line_start": chunk.get("line_start", 1),
+        "line_end": chunk.get("line_end", 1),
+        "lang": chunk.get("lang"),
+    }
+    if chunk.get("rel_path"):
+        payload["rel_path"] = chunk["rel_path"]
+
+    context.qdrant.upsert_tenant(
+        tenant_id,
+        [
+            PointStruct(
+                id=chunk["chunk_id"],
+                vector=vector,
+                payload=payload,
+            )
+        ],
+    )
+
+    if repo_id not in settings.privacy_repo_ids:
+        context.opensearch.bulk_upsert_tenant(
+            tenant_id,
+            [
+                {
+                    "chunk_id": chunk["chunk_id"],
+                    "repo_id": repo_id,
+                    "path_tokens": chunk["path_tokens"],
+                    "rel_path": payload.get("rel_path", ""),
+                    "lang": payload.get("lang"),
+                    "line_start": payload["line_start"],
+                    "line_end": payload["line_end"],
+                    "text": text,
+                }
+            ],
+        )
+
+    return {"status": "ok", "chunk_id": chunk["chunk_id"]}

--- a/server/app/api/routes/metrics.py
+++ b/server/app/api/routes/metrics.py
@@ -1,0 +1,15 @@
+"""Metrics endpoint."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+
+from app.api.context import AppContext
+from app.api.deps import provide_context
+
+router = APIRouter(prefix="/v1")
+
+
+@router.get("/metrics")
+async def metrics(context: AppContext = Depends(provide_context)) -> dict[str, object]:
+    return context.stats.snapshot()

--- a/server/app/api/routes/search.py
+++ b/server/app/api/routes/search.py
@@ -1,0 +1,184 @@
+"""Search-related endpoints."""
+
+from __future__ import annotations
+
+import os
+import time
+import uuid
+import logging
+
+from fastapi import APIRouter, Depends, Header, Request
+
+from app.api.context import AppContext
+from app.api.deps import provide_context
+from app.config import settings
+from app.models.schemas import (
+    FetchLinesRequest,
+    FetchLinesResponse,
+    SearchHit,
+    SearchRequest,
+    SearchResponse,
+)
+from app.utils.jsonl import append_jsonl
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/v1")
+
+
+@router.post("/search", response_model=SearchResponse)
+async def search(
+    req: SearchRequest,
+    request: Request,
+    *,
+    x_api_key: str | None = Header(default=None),
+    context: AppContext = Depends(provide_context),
+) -> SearchResponse:
+    context.api_keys.enforce(req.tenant_id, x_api_key)
+
+    client_key = x_api_key or (request.client.host if request.client else "anonymous")
+    context.rate_limiter.check(client_key)
+
+    start = time.time()
+
+    logger.info(
+        "search_started",
+        extra={
+            "tenant_id": req.tenant_id,
+            "repo_id": req.repo_id,
+            "query": req.query,
+            "lang": req.lang,
+            "top_k": req.top_k,
+        },
+    )
+
+    cache_key = (
+        req.tenant_id,
+        req.repo_id,
+        req.query,
+        req.lang,
+        req.dir_hint,
+        req.exclude_tests,
+        req.top_k,
+    )
+    cached_entry = context.search_cache.get(cache_key)
+
+    if cached_entry:
+        hits = cached_entry.hits
+        debug = cached_entry.debug
+        bucket = cached_entry.bucket
+        search_id = cached_entry.search_id
+        cache_hit = True
+    else:
+        search_id = uuid.uuid4().hex[:16]
+        bucket = "control" if int(search_id[-1], 16) % 2 == 0 else "variant"
+
+        original_alpha, original_beta = context.searcher.alpha, context.searcher.beta
+        if bucket == "variant":
+            context.searcher.alpha = float(os.getenv("AB_VARIANT_ALPHA", context.searcher.alpha))
+            context.searcher.beta = float(os.getenv("AB_VARIANT_BETA", context.searcher.beta))
+
+        hits, debug = context.searcher.search_with_debug(
+            tenant_id=req.tenant_id,
+            repo_id=req.repo_id,
+            query=req.query,
+            top_k=req.top_k,
+            filters={
+                "lang": req.lang,
+                "dir_hint": req.dir_hint,
+                "exclude_tests": req.exclude_tests,
+            },
+        )
+        context.searcher.alpha, context.searcher.beta = original_alpha, original_beta
+
+        context.search_cache.set(
+            cache_key,
+            hits=hits,
+            debug=debug,
+            bucket=bucket,
+            search_id=search_id,
+        )
+        cache_hit = False
+
+    need_fetch = req.repo_id in settings.privacy_repo_ids
+
+    append_jsonl(
+        "/app/server/data/search_log.jsonl",
+        {
+            "search_id": search_id,
+            "tenant_id": req.tenant_id,
+            "repo_id": req.repo_id,
+            "query": req.query,
+            "timestamp": time.time(),
+            "candidates": debug,
+            "bucket": bucket,
+        },
+    )
+
+    duration_ms = int((time.time() - start) * 1000)
+
+    logger.info(
+        "search_completed",
+        extra={
+            "tenant_id": req.tenant_id,
+            "repo_id": req.repo_id,
+            "query": req.query,
+            "top_k": req.top_k,
+            "cache_hit": cache_hit,
+            "variant": bucket,
+            "duration_ms": duration_ms,
+            "result_count": len(hits),
+            "search_id": search_id,
+        },
+    )
+
+    if debug:
+        logger.debug(
+            "search_candidates",
+            extra={
+                "tenant_id": req.tenant_id,
+                "repo_id": req.repo_id,
+                "query": req.query,
+                "variant": bucket,
+                "cache_hit": cache_hit,
+                "search_id": search_id,
+                "candidates": debug,
+            },
+        )
+
+    context.stats.record_search(duration_ms)
+
+    return SearchResponse(
+        search_id=search_id,
+        bucket=bucket,
+        need_fetch_lines=need_fetch,
+        hits=[SearchHit(**hit) for hit in hits],
+    )
+
+
+@router.post("/search/fetch-lines", response_model=FetchLinesResponse)
+async def fetch_lines(
+    req: FetchLinesRequest,
+    *,
+    x_api_key: str | None = Header(default=None),
+    context: AppContext = Depends(provide_context),
+) -> FetchLinesResponse:
+    context.api_keys.enforce(req.tenant_id, x_api_key)
+
+    passages = [item.raw_lines for item in req.items]
+    scores = context.reranker.rerank(req.query, passages)
+    ranked = sorted(zip(req.items, scores), key=lambda pair: pair[1], reverse=True)[: req.top_k]
+
+    hits = [
+        SearchHit(
+            chunk_id=item.chunk_id,
+            score=float(score),
+            path_tokens=[],
+            line_span=[0, 0],
+            repo_id=req.repo_id,
+            preview=None,
+        )
+        for item, score in ranked
+    ]
+
+    return FetchLinesResponse(hits=hits)

--- a/server/app/api/routes/tenant.py
+++ b/server/app/api/routes/tenant.py
@@ -1,0 +1,21 @@
+"""Tenant-related endpoints."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from app.utils.vault import get_current_salt
+
+router = APIRouter(prefix="/v1")
+
+
+@router.get("/tenant/salt")
+async def get_tenant_salt(tenant_id: str = "default") -> dict[str, object]:
+    salt = get_current_salt(tenant_id)
+    if not salt:
+        return {"tenant_id": tenant_id, "salt_ver": 0, "salt": ""}
+    return {
+        "tenant_id": tenant_id,
+        "salt_ver": salt.get("ver", 0),
+        "salt": salt.get("value", ""),
+    }

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -1,281 +1,103 @@
+"""FastAPI application entrypoint."""
 
+from __future__ import annotations
+
+import json
 import logging
-import time, uuid, threading, json, pathlib, os
-from collections import OrderedDict
+import os
+import pathlib
 
-from fastapi import FastAPI, Request, Header, HTTPException
+from fastapi import FastAPI
 
+from app.api import api_router
+from app.api.context import AppContext
 from app.config import settings
 from app.index.opensearch_store import OSStore
 from app.index.qdrant_store import QdrantStore
-from app.models.schemas import (
-    FetchLinesRequest,
-    FetchLinesResponse,
-    FeedbackRequest,
-    FeedbackResponse,
-    SearchHit,
-    SearchRequest,
-    SearchResponse,
-    UploadRequest,
-)
 from app.search.hybrid_search import HybridSearch
 from app.search.providers.embedding import build_embedding_provider
 from app.search.providers.reranker import build_reranker_provider
 from app.search.reranker import CrossEncoderReranker
-from app.utils.jsonl import append_jsonl
+from app.services.api_key import APIKeyValidator
+from app.services.cache import EmbeddingCache, SearchCache
+from app.services.metrics import StatsTracker
+from app.services.rate_limit import RateLimiter
 from app.utils.logging import RequestIdMiddleware, configure_logging
-from app.utils.s3_utils import get_object_text
-from app.utils.vault import get_current_salt
-from qdrant_client.http.models import PointStruct
 
 configure_logging()
-
 logger = logging.getLogger(__name__)
 
-app = FastAPI(title="Hybrid Code Indexing (Advanced)")
-app.add_middleware(RequestIdMiddleware)
+TENANT_FILE = pathlib.Path("/app/server/data/tenants.json")
+REQUIRE_API_KEY = os.getenv("REQUIRE_API_KEY", "false").lower() == "true"
+SEARCH_RATE_PER_MIN = int(os.getenv("LIMIT_SEARCH_PER_MINUTE", "120"))
+EMBED_CACHE_SIZE = int(os.getenv("EMBED_CACHE_SIZE", "10000"))
+SEARCH_CACHE_TTL_S = int(os.getenv("SEARCH_CACHE_TTL_S", "30"))
 
-embed_provider, embed_provider_key, embed_fallback = build_embedding_provider(
-    os.getenv("EMBED_PROVIDER"), settings.embed_model
-)
-if embed_fallback:
-    logger.warning(
-        "Unknown embedding provider '%s'; falling back to '%s'",
-        embed_fallback,
-        embed_provider_key,
+
+def _load_tenant_keys(path: pathlib.Path) -> dict[str, list[str]]:
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:  # pragma: no cover - defensive log path
+        logger.exception("Failed to read tenant key file: %s", path)
+        return {}
+    if not isinstance(data, dict):
+        logger.warning("Tenant key file %s does not contain a mapping", path)
+        return {}
+    normalized: dict[str, list[str]] = {}
+    for tenant, keys in data.items():
+        if isinstance(keys, list):
+            normalized[str(tenant)] = [str(key) for key in keys]
+    return normalized
+
+
+def create_app() -> FastAPI:
+    embed_provider, embed_key, embed_fallback = build_embedding_provider(
+        os.getenv("EMBED_PROVIDER"), settings.embed_model
     )
-
-qdrant = QdrantStore()
-os_store = OSStore()
-searcher = HybridSearch(qdrant, os_store, embed_provider)
-
-reranker_provider, reranker_key, reranker_fallback = build_reranker_provider(
-    os.getenv("RERANKER_PROVIDER"), settings.reranker_model
-)
-if reranker_fallback:
-    logger.warning(
-        "Unknown reranker provider '%s'; falling back to '%s'",
-        reranker_fallback,
-        reranker_key,
-    )
-reranker = CrossEncoderReranker(provider=reranker_provider)
-
-# --- RBAC / Rate limit / Cache / Metrics ---
-TENANT_KEYS = {}
-p = pathlib.Path("/app/server/data/tenants.json")
-if p.exists():
-    try: TENANT_KEYS = json.loads(p.read_text(encoding="utf-8"))
-    except Exception: TENANT_KEYS = {}
-
-REQUIRE_API_KEY = (os.getenv("REQUIRE_API_KEY","false").lower()=="true")
-SEARCH_RATE_PER_MIN = int(os.getenv("LIMIT_SEARCH_PER_MINUTE","120"))
-EMBED_CACHE_SIZE = int(os.getenv("EMBED_CACHE_SIZE","10000"))
-SEARCH_CACHE_TTL_S = int(os.getenv("SEARCH_CACHE_TTL_S","30"))
-AB_VARIANT_ALPHA = float(os.getenv("AB_VARIANT_ALPHA", str(settings.alpha_vec)))
-AB_VARIANT_BETA  = float(os.getenv("AB_VARIANT_BETA", str(settings.beta_bm25)))
-
-STATS = {"search_total":0, "search_err":0, "feedback_total":0, "index_total":0, "avg_search_ms":0.0}
-_stats_lock = threading.Lock()
-
-class EmbedCache:
-    def __init__(self, max_size=10000):
-        self.max=max_size; self.d=OrderedDict(); self.lock=threading.Lock()
-    def get(self, key):
-        with self.lock:
-            if key in self.d:
-                v=self.d.pop(key); self.d[key]=v; return v
-            return None
-    def put(self, key, val):
-        with self.lock:
-            if key in self.d: self.d.pop(key)
-            self.d[key]=val
-            if len(self.d)>self.max: self.d.popitem(last=False)
-
-EMB_CACHE = EmbedCache(EMBED_CACHE_SIZE)
-
-def encode_cached(text: str):
-    v = EMB_CACHE.get(text)
-    if v is not None: return v
-    vec = embed_provider.encode([text], normalize_embeddings=True)[0]
-    EMB_CACHE.put(text, vec)
-    return vec
-
-_rate = {}
-def check_rate(key: str):
-    now = int(time.time()//60)
-    b = _rate.get(key)
-    if not b or b["minute"]!=now: b={"minute":now,"count":0}; _rate[key]=b
-    b["count"] += 1
-    if b["count"] > SEARCH_RATE_PER_MIN: raise HTTPException(429, "rate limit exceeded")
-
-def require_key(tenant_id: str, api_key: str | None):
-    if not REQUIRE_API_KEY: return
-    if not api_key: raise HTTPException(401, "missing x-api-key")
-    allowed = set(TENANT_KEYS.get(tenant_id, []))
-    if api_key not in allowed: raise HTTPException(403, "invalid api key")
-
-_search_cache = {}
-def get_cache(key):
-    v=_search_cache.get(key)
-    if not v: return None
-    if (time.time()-v["t"])>SEARCH_CACHE_TTL_S: _search_cache.pop(key,None); return None
-    return v["hits"]
-def set_cache(key, hits): _search_cache[key]={"t":time.time(),"hits":hits}
-
-@app.get("/v1/tenant/salt")
-async def get_tenant_salt(tenant_id: str = "default"):
-    s = get_current_salt(tenant_id)
-    if not s: return {"tenant_id": tenant_id, "salt_ver": 0, "salt": ""}
-    return {"tenant_id": tenant_id, "salt_ver": s.get("ver", 0), "salt": s.get("value","")}
-
-@app.post("/v1/index/upload")
-async def upload(req: UploadRequest, x_api_key: str | None = Header(default=None)):
-    require_key(req.chunks[0].tenant_id if req.chunks else "default", x_api_key)
-    points = []; os_docs = []
-    tenant = req.chunks[0].tenant_id if req.chunks else "default"
-    for c in req.chunks:
-        payload = {"chunk_id": c.chunk_id, "repo_id": c.repo_id, "path_tokens": c.path_tokens,
-                   "line_start": c.line_start, "line_end": c.line_end, "lang": c.lang}
-        if c.rel_path is not None: payload["rel_path"] = c.rel_path
-        if c.privacy_mode:
-            assert c.vector is not None, "privacy_mode=True면 vector 필요"
-            vec = c.vector
-        else:
-            assert c.text is not None, "privacy_mode=False면 text 필요"
-            vec = encode_cached(c.text)
-            if (c.repo_id not in settings.privacy_repo_ids):
-                os_docs.append({"chunk_id": c.chunk_id, "repo_id": c.repo_id, "path_tokens": c.path_tokens,
-                                "rel_path": c.rel_path or "", "lang": c.lang,
-                                "line_start": c.line_start, "line_end": c.line_end, "text": c.text})
-        points.append(PointStruct(id=c.chunk_id, vector=vec, payload=payload))
-
-    if points: qdrant.upsert_tenant(tenant, points)
-    if os_docs: os_store.bulk_upsert_tenant(tenant, os_docs)
-    with _stats_lock: STATS["index_total"] += len(req.chunks)
-    return {"status":"ok","qdrant":len(points),"opensearch":len(os_docs)}
-
-@app.post("/v1/index/commit_tus")
-async def commit_tus(body: dict, x_api_key: str | None = Header(default=None)):
-    tenant_id = body.get("tenant_id","default")
-    require_key(tenant_id, x_api_key)
-    repo_id = body.get("repo_id"); chunk = body.get("chunk",{}); tus_key = body.get("tus_key")
-    assert repo_id and chunk and tus_key, "invalid payload"
-    key = f"uploads/{tus_key}"
-    text = get_object_text(key)
-    vec = encode_cached(text)
-    payload = {"chunk_id": chunk["chunk_id"], "repo_id": repo_id, "path_tokens": chunk["path_tokens"],
-               "line_start": chunk.get("line_start",1), "line_end": chunk.get("line_end",1), "lang": chunk.get("lang")}
-    if chunk.get("rel_path"): payload["rel_path"] = chunk["rel_path"]
-    qdrant.upsert_tenant(tenant_id, [PointStruct(id=chunk["chunk_id"], vector=vec, payload=payload)])
-    if repo_id not in settings.privacy_repo_ids:
-        os_store.bulk_upsert_tenant(tenant_id, [{"chunk_id": chunk["chunk_id"], "repo_id": repo_id, "path_tokens": chunk["path_tokens"],
-                                                 "rel_path": payload.get("rel_path",""), "lang": payload.get("lang"),
-                                                 "line_start": payload["line_start"], "line_end": payload["line_end"], "text": text}])
-    return {"status":"ok","chunk_id":chunk["chunk_id"]}
-
-@app.post("/v1/search", response_model=SearchResponse)
-async def search(req: SearchRequest, request: Request, x_api_key: str | None = Header(default=None)):
-    require_key(req.tenant_id, x_api_key); key = x_api_key or request.client.host
-    # Rate limit
-    now_min = int(time.time()//60)
-    ipkey = f"{key}:{now_min}";
-    # reuse check_rate via simple inline
-    hit = getattr(search, "_rate", {}); cnt = hit.get(ipkey,0)+1
-    if cnt > int(os.getenv("LIMIT_SEARCH_PER_MINUTE","120")): raise HTTPException(429, "rate limit exceeded")
-    hit[ipkey]=cnt; setattr(search, "_rate", hit)
-
-    t0 = time.time()
-    logger.info(
-        "search_started",
-        extra={
-            "tenant_id": req.tenant_id,
-            "repo_id": req.repo_id,
-            "query": req.query,
-            "lang": req.lang,
-            "top_k": req.top_k,
-        },
-    )
-
-    cache_key=(req.tenant_id, req.repo_id, req.query, req.lang, req.dir_hint, req.exclude_tests, req.top_k)
-    cached_entry = getattr(search, "_cache", {}).get(cache_key)
-    cache_valid = (
-        cached_entry is not None
-        and (time.time()-cached_entry["t"])<=int(os.getenv("SEARCH_CACHE_TTL_S","30"))
-    )
-
-    if cache_valid:
-        hits = cached_entry["hits"]
-        debug = cached_entry.get("debug", [])
-        sid = cached_entry.get("search_id", uuid.uuid4().hex[:16])
-        bucket = cached_entry.get("bucket", "control")
-    else:
-        # A/B bucket
-        sid = uuid.uuid4().hex[:16]
-        bucket = 'control' if int(sid[-1],16)%2==0 else 'variant'
-        # override alpha/beta for variant
-        orig = (searcher.alpha, searcher.beta)
-        if bucket == 'variant':
-            searcher.alpha, searcher.beta = float(os.getenv("AB_VARIANT_ALPHA", searcher.alpha)), float(os.getenv("AB_VARIANT_BETA", searcher.beta))
-        hits, debug = searcher.search_with_debug(tenant_id=req.tenant_id, repo_id=req.repo_id, query=req.query, top_k=req.top_k,
-                                                 filters={"lang": req.lang, "dir_hint": req.dir_hint, "exclude_tests": req.exclude_tests})
-        searcher.alpha, searcher.beta = orig
-        # store to cache
-        c = getattr(search, "_cache", {})
-        c[cache_key]={"t": time.time(), "hits": hits, "bucket": bucket, "search_id": sid, "debug": debug}
-        setattr(search, "_cache", c)
-
-    need_fetch = (req.repo_id in settings.privacy_repo_ids)
-    append_jsonl("/app/server/data/search_log.jsonl", {"search_id": sid, "tenant_id": req.tenant_id, "repo_id": req.repo_id,
-                                                       "query": req.query, "timestamp": time.time(), "candidates": debug, "bucket": bucket})
-    duration_ms = int((time.time()-t0)*1000)
-    logger.info(
-        "search_completed",
-        extra={
-            "tenant_id": req.tenant_id,
-            "repo_id": req.repo_id,
-            "query": req.query,
-            "top_k": req.top_k,
-            "cache_hit": cache_valid,
-            "variant": bucket,
-            "duration_ms": duration_ms,
-            "result_count": len(hits),
-            "search_id": sid,
-        },
-    )
-    if debug:
-        logger.debug(
-            "search_candidates",
-            extra={
-                "tenant_id": req.tenant_id,
-                "repo_id": req.repo_id,
-                "query": req.query,
-                "variant": bucket,
-                "cache_hit": cache_valid,
-                "search_id": sid,
-                "candidates": debug,
-            },
+    if embed_fallback:
+        logger.warning(
+            "Unknown embedding provider '%s'; falling back to '%s'",
+            embed_fallback,
+            embed_key,
         )
-    with _stats_lock:
-        STATS["search_total"] += 1
-        STATS["avg_search_ms"] = (STATS["avg_search_ms"]*0.99 + (time.time()-t0)*1000*0.01)
-    return SearchResponse(search_id=sid, bucket=bucket, need_fetch_lines=need_fetch, hits=[SearchHit(**h) for h in hits])
 
-@app.post("/v1/search/fetch-lines", response_model=FetchLinesResponse)
-async def fetch_lines(req: FetchLinesRequest, x_api_key: str | None = Header(default=None)):
-    require_key(req.tenant_id, x_api_key)
-    passages = [it.raw_lines for it in req.items]
-    scores = reranker.rerank(req.query, passages)
-    pairs = sorted(zip(req.items, scores), key=lambda x: x[1], reverse=True)[:req.top_k]
-    hits = [SearchHit(chunk_id=it.chunk_id, score=float(sc), path_tokens=[], line_span=[0,0], repo_id=req.repo_id, preview=None)
-            for it, sc in pairs]
-    return FetchLinesResponse(hits=hits)
+    reranker_provider, reranker_key, reranker_fallback = build_reranker_provider(
+        os.getenv("RERANKER_PROVIDER"), settings.reranker_model
+    )
+    if reranker_fallback:
+        logger.warning(
+            "Unknown reranker provider '%s'; falling back to '%s'",
+            reranker_fallback,
+            reranker_key,
+        )
 
-@app.post("/v1/feedback", response_model=FeedbackResponse)
-async def feedback(req: FeedbackRequest, x_api_key: str | None = Header(default=None)):
-    append_jsonl("/app/server/data/feedback_log.jsonl", {"search_id": req.search_id, "clicked_chunk_id": req.clicked_chunk_id,
-                                                         "grade": int(req.grade), "timestamp": time.time()})
-    with _stats_lock: STATS["feedback_total"] += 1
-    return FeedbackResponse(status="ok")
+    qdrant = QdrantStore()
+    opensearch = OSStore()
 
-@app.get("/v1/metrics")
-async def metrics(): return STATS
+    searcher = HybridSearch(qdrant, opensearch, embed_provider)
+    reranker = CrossEncoderReranker(provider=reranker_provider)
+
+    context = AppContext(
+        qdrant=qdrant,
+        opensearch=opensearch,
+        searcher=searcher,
+        reranker=reranker,
+        embedding_cache=EmbeddingCache(embed_provider, EMBED_CACHE_SIZE),
+        search_cache=SearchCache(SEARCH_CACHE_TTL_S),
+        rate_limiter=RateLimiter(SEARCH_RATE_PER_MIN),
+        api_keys=APIKeyValidator(_load_tenant_keys(TENANT_FILE), REQUIRE_API_KEY),
+        stats=StatsTracker(),
+    )
+
+    app = FastAPI(title="Hybrid Code Indexing (Advanced)")
+    app.state.context = context  # type: ignore[attr-defined]
+
+    app.add_middleware(RequestIdMiddleware)
+    app.include_router(api_router)
+
+    return app
+
+
+app = create_app()

--- a/server/app/services/api_key.py
+++ b/server/app/services/api_key.py
@@ -1,0 +1,25 @@
+"""API key enforcement helpers."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from fastapi import HTTPException
+
+
+class APIKeyValidator:
+    def __init__(self, tenant_keys: dict[str, Iterable[str]], require_api_key: bool) -> None:
+        self._tenant_keys = {
+            tenant: set(keys)
+            for tenant, keys in (tenant_keys or {}).items()
+        }
+        self._require = require_api_key
+
+    def enforce(self, tenant_id: str, api_key: str | None) -> None:
+        if not self._require:
+            return
+        if not api_key:
+            raise HTTPException(status_code=401, detail="missing x-api-key")
+        allowed = self._tenant_keys.get(tenant_id, set())
+        if api_key not in allowed:
+            raise HTTPException(status_code=403, detail="invalid api key")

--- a/server/app/services/cache.py
+++ b/server/app/services/cache.py
@@ -1,0 +1,105 @@
+"""Caching utilities for application services."""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections import OrderedDict
+from dataclasses import dataclass
+from typing import Any, Callable, Hashable, Iterable, Optional
+
+from app.search.providers.embedding import EmbeddingProvider
+
+
+class _LRUCache:
+    """Thread-safe LRU cache used for embedding reuse."""
+
+    def __init__(self, max_size: int) -> None:
+        self._max_size = max_size
+        self._lock = threading.Lock()
+        self._store: OrderedDict[str, list[float]] = OrderedDict()
+
+    def get(self, key: str) -> Optional[list[float]]:
+        with self._lock:
+            if key not in self._store:
+                return None
+            value = self._store.pop(key)
+            self._store[key] = value
+            return value
+
+    def put(self, key: str, value: list[float]) -> None:
+        with self._lock:
+            if key in self._store:
+                self._store.pop(key)
+            self._store[key] = value
+            while len(self._store) > self._max_size:
+                self._store.popitem(last=False)
+
+
+class EmbeddingCache:
+    """Provides cached access to embedding encodings."""
+
+    def __init__(self, provider: EmbeddingProvider, max_size: int) -> None:
+        self._provider = provider
+        self._cache = _LRUCache(max_size)
+
+    def encode(self, text: str) -> list[float]:
+        cached = self._cache.get(text)
+        if cached is not None:
+            return cached
+        vector = self._provider.encode([text], normalize_embeddings=True)[0]
+        self._cache.put(text, vector)
+        return vector
+
+
+@dataclass(frozen=True)
+class SearchCacheEntry:
+    hits: list[dict[str, Any]]
+    debug: list[dict[str, Any]]
+    bucket: str
+    search_id: str
+    timestamp: float
+
+
+class SearchCache:
+    """Cache for search responses with TTL semantics."""
+
+    def __init__(self, ttl_seconds: int, time_func: Callable[[], float] | None = None) -> None:
+        self._ttl = ttl_seconds
+        self._time = time_func or time.time
+        self._lock = threading.Lock()
+        self._store: dict[Hashable, SearchCacheEntry] = {}
+
+    def get(self, key: Hashable) -> Optional[SearchCacheEntry]:
+        now = self._time()
+        with self._lock:
+            entry = self._store.get(key)
+            if entry is None:
+                return None
+            if now - entry.timestamp > self._ttl:
+                self._store.pop(key, None)
+                return None
+            return entry
+
+    def set(
+        self,
+        key: Hashable,
+        *,
+        hits: Iterable[dict[str, Any]],
+        debug: Iterable[dict[str, Any]] | None = None,
+        bucket: str,
+        search_id: str,
+    ) -> None:
+        entry = SearchCacheEntry(
+            hits=list(hits),
+            debug=list(debug or []),
+            bucket=bucket,
+            search_id=search_id,
+            timestamp=self._time(),
+        )
+        with self._lock:
+            self._store[key] = entry
+
+    def clear(self) -> None:
+        with self._lock:
+            self._store.clear()

--- a/server/app/services/metrics.py
+++ b/server/app/services/metrics.py
@@ -1,0 +1,40 @@
+"""Application metrics tracking."""
+
+from __future__ import annotations
+
+import threading
+from typing import Any, Dict
+
+
+class StatsTracker:
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._stats: Dict[str, Any] = {
+            "search_total": 0,
+            "search_err": 0,
+            "feedback_total": 0,
+            "index_total": 0,
+            "avg_search_ms": 0.0,
+        }
+
+    def record_search(self, duration_ms: float) -> None:
+        with self._lock:
+            self._stats["search_total"] += 1
+            # exponential moving average similar to previous behaviour
+            self._stats["avg_search_ms"] = (
+                self._stats["avg_search_ms"] * 0.99 + duration_ms * 0.01
+            )
+
+    def increment_index(self, amount: int) -> None:
+        if amount <= 0:
+            return
+        with self._lock:
+            self._stats["index_total"] += amount
+
+    def increment_feedback(self) -> None:
+        with self._lock:
+            self._stats["feedback_total"] += 1
+
+    def snapshot(self) -> Dict[str, Any]:
+        with self._lock:
+            return dict(self._stats)

--- a/server/app/services/rate_limit.py
+++ b/server/app/services/rate_limit.py
@@ -1,0 +1,46 @@
+"""Rate limiting helpers."""
+
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import dataclass
+from typing import Callable
+
+from fastapi import HTTPException
+
+
+@dataclass
+class _Bucket:
+    minute: int
+    count: int
+
+
+class RateLimiter:
+    """Simple in-memory rate limiter with per-minute buckets."""
+
+    def __init__(
+        self,
+        limit_per_minute: int,
+        *,
+        time_func: Callable[[], float] | None = None,
+    ) -> None:
+        self._limit = limit_per_minute
+        self._time = time_func or time.time
+        self._lock = threading.Lock()
+        self._buckets: dict[str, _Bucket] = {}
+
+    def check(self, key: str) -> None:
+        minute = int(self._time() // 60)
+        with self._lock:
+            bucket = self._buckets.get(key)
+            if bucket is None or bucket.minute != minute:
+                bucket = _Bucket(minute=minute, count=0)
+                self._buckets[key] = bucket
+            bucket.count += 1
+            if bucket.count > self._limit:
+                raise HTTPException(status_code=429, detail="rate limit exceeded")
+
+    def clear(self) -> None:
+        with self._lock:
+            self._buckets.clear()

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException
+
+from app.services.cache import EmbeddingCache, SearchCache
+from app.services.rate_limit import RateLimiter
+
+
+class DummyProvider:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def encode(self, texts, normalize_embeddings=True):  # type: ignore[override]
+        self.calls += 1
+        return [[float(len(texts))] for _ in texts]
+
+
+def test_embedding_cache_reuses_vectors():
+    provider = DummyProvider()
+    cache = EmbeddingCache(provider, max_size=10)
+
+    first = cache.encode("hello")
+    second = cache.encode("hello")
+
+    assert first == second
+    assert provider.calls == 1
+
+
+def test_search_cache_honours_ttl():
+    now = [0.0]
+
+    def fake_time() -> float:
+        return now[0]
+
+    cache = SearchCache(ttl_seconds=10, time_func=fake_time)
+    cache.set("key", hits=[{"chunk_id": 1}], bucket="control", search_id="abc")
+    assert cache.get("key") is not None
+    now[0] = 11
+    assert cache.get("key") is None
+
+
+def test_rate_limiter_blocks_after_limit():
+    now = [0.0]
+
+    def fake_time() -> float:
+        return now[0]
+
+    limiter = RateLimiter(limit_per_minute=2, time_func=fake_time)
+    limiter.check("tenant")
+    limiter.check("tenant")
+    with pytest.raises(HTTPException):
+        limiter.check("tenant")
+    now[0] = 61
+    limiter.check("tenant")  # new window succeeds


### PR DESCRIPTION
## Summary
- restructure the FastAPI app to use dedicated router modules and an AppContext container
- extract caches, API key validation, rate limiting, and metrics tracking into reusable services
- add unit tests for the new services and document the modular API layout

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68de10778548832eabc12634c9f0efd5