### PR TITLE
Add Redis-backed caches and rate limiting

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,6 +51,10 @@ services:
     depends_on: [minio, mc]
     ports: ["1080:1080"]
 
+  redis:
+    image: redis:7.4-alpine
+    ports: ["6379:6379"]
+
   server:
     build: ./server
     environment:
@@ -67,8 +71,10 @@ services:
       - REQUIRE_API_KEY=false
       - LIMIT_SEARCH_PER_MINUTE=120
       - EMBED_CACHE_SIZE=10000
+      - EMBED_CACHE_TTL_S=3600
       - SEARCH_CACHE_TTL_S=30
-    depends_on: [qdrant, opensearch, minio, tusd]
+      - REDIS_URL=redis://redis:6379/0
+    depends_on: [qdrant, opensearch, minio, tusd, redis]
     ports: ["8000:8000"]
 
 volumes:

--- a/docs/Operations.md
+++ b/docs/Operations.md
@@ -3,9 +3,20 @@
 ## Environment variables
 - ALPHA_VEC, BETA_BM25, RRF_K, TOP_K_VECTOR/BM25/FINAL_K,
   EMBED_MODEL, RERANKER_MODEL, LEARNED_RANKER_PATH,
-  REQUIRE_API_KEY, LIMIT_SEARCH_PER_MINUTE, EMBED_CACHE_SIZE, SEARCH_CACHE_TTL_S,
+  REQUIRE_API_KEY, LIMIT_SEARCH_PER_MINUTE,
+  EMBED_CACHE_SIZE, EMBED_CACHE_TTL_S,
+  SEARCH_CACHE_TTL_S,
   AB_VARIANT_ALPHA, AB_VARIANT_BETA,
-  QDRANT_*, OPENSEARCH_*, S3_*, VAULT_*
+  QDRANT_*, OPENSEARCH_*, S3_*, VAULT_*, REDIS_URL
+
+## Caching and rate limiting
+- Redis is now the default backing store for embedding reuse, search response caching
+  and request rate limiting. The service connects to ``REDIS_URL`` (defaults to
+  ``redis://redis:6379/0`` in Docker) and gracefully falls back to the original
+  in-memory behaviour when Redis is unavailable.
+- Adjust ``EMBED_CACHE_TTL_S`` to control how long embedding vectors remain in Redis.
+- ``SEARCH_CACHE_TTL_S`` continues to control the TTL for search responses across
+  all application instances.
 
 ## Logging and observability
 - Application logs are emitted as structured JSON. See [Logging & Request Tracing](./Logging.md)

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ scikit-learn==1.5.1
 pydantic==2.9.2
 python-multipart==0.0.9
 httpx==0.27.0
+redis==5.0.8
 requests==2.32.3
 blake3==0.4.1
 pathspec==0.12.1

--- a/server/app/services/cache.py
+++ b/server/app/services/cache.py
@@ -2,13 +2,26 @@
 
 from __future__ import annotations
 
+import hashlib
+import json
+import logging
 import threading
 import time
 from collections import OrderedDict
 from dataclasses import dataclass
-from typing import Any, Callable, Hashable, Iterable, Optional
+from typing import Any, Callable, Hashable, Iterable
+
+try:  # pragma: no cover - optional dependency
+    from redis import Redis
+    from redis.exceptions import RedisError
+except ModuleNotFoundError:  # pragma: no cover - fallback for tests
+    from app.utils.redis_client import RedisError
+
+    Redis = Any  # type: ignore[assignment]
 
 from app.search.providers.embedding import EmbeddingProvider
+
+logger = logging.getLogger(__name__)
 
 
 class _LRUCache:
@@ -19,7 +32,7 @@ class _LRUCache:
         self._lock = threading.Lock()
         self._store: OrderedDict[str, list[float]] = OrderedDict()
 
-    def get(self, key: str) -> Optional[list[float]]:
+    def get(self, key: str) -> list[float] | None:
         with self._lock:
             if key not in self._store:
                 return None
@@ -37,18 +50,63 @@ class _LRUCache:
 
 
 class EmbeddingCache:
-    """Provides cached access to embedding encodings."""
+    """Provides cached access to embedding encodings with optional Redis backing."""
 
-    def __init__(self, provider: EmbeddingProvider, max_size: int) -> None:
+    def __init__(
+        self,
+        provider: EmbeddingProvider,
+        max_size: int,
+        *,
+        redis_client: Redis | None = None,
+        ttl_seconds: int | None = None,
+    ) -> None:
         self._provider = provider
         self._cache = _LRUCache(max_size)
+        self._redis = redis_client
+        self._ttl = ttl_seconds
+        self._redis_enabled = redis_client is not None
+        self._redis_warned = False
+
+    def _redis_key(self, text: str) -> str:
+        digest = hashlib.sha256(text.encode("utf-8")).hexdigest()
+        return f"embeddings:{digest}"
+
+    def _disable_redis(self, message: str, *, exc: Exception | None = None) -> None:
+        if not self._redis_warned:
+            logger.warning("%s; falling back to local embedding cache", message, exc_info=exc)
+            self._redis_warned = True
+        self._redis_enabled = False
 
     def encode(self, text: str) -> list[float]:
         cached = self._cache.get(text)
         if cached is not None:
             return cached
+
+        if self._redis_enabled and self._redis is not None:
+            key = self._redis_key(text)
+            try:
+                payload = self._redis.get(key)
+                if payload is not None:
+                    vector = json.loads(payload.decode("utf-8"))
+                    self._cache.put(text, vector)
+                    return vector
+            except (RedisError, json.JSONDecodeError) as exc:
+                self._disable_redis("Redis embedding cache read failed", exc=exc)
+
         vector = self._provider.encode([text], normalize_embeddings=True)[0]
         self._cache.put(text, vector)
+
+        if self._redis_enabled and self._redis is not None:
+            key = self._redis_key(text)
+            try:
+                data = json.dumps(vector).encode("utf-8")
+                if self._ttl:
+                    self._redis.set(key, data, ex=self._ttl)
+                else:
+                    self._redis.set(key, data)
+            except RedisError as exc:
+                self._disable_redis("Redis embedding cache write failed", exc=exc)
+
         return vector
 
 
@@ -62,15 +120,82 @@ class SearchCacheEntry:
 
 
 class SearchCache:
-    """Cache for search responses with TTL semantics."""
+    """Cache for search responses with TTL semantics and optional Redis."""
 
-    def __init__(self, ttl_seconds: int, time_func: Callable[[], float] | None = None) -> None:
+    def __init__(
+        self,
+        ttl_seconds: int,
+        *,
+        time_func: Callable[[], float] | None = None,
+        redis_client: Redis | None = None,
+    ) -> None:
         self._ttl = ttl_seconds
         self._time = time_func or time.time
         self._lock = threading.Lock()
         self._store: dict[Hashable, SearchCacheEntry] = {}
+        self._redis = redis_client
+        self._redis_enabled = redis_client is not None
+        self._redis_warned = False
 
-    def get(self, key: Hashable) -> Optional[SearchCacheEntry]:
+    def _redis_key(self, key: Hashable) -> str:
+        try:
+            serialised = json.dumps(key, sort_keys=True, default=str)
+        except TypeError:
+            serialised = repr(key)
+        digest = hashlib.sha256(serialised.encode("utf-8")).hexdigest()
+        return f"search-cache:{digest}"
+
+    def _disable_redis(self, message: str, *, exc: Exception | None = None) -> None:
+        if not self._redis_warned:
+            logger.warning("%s; falling back to local search cache", message, exc_info=exc)
+            self._redis_warned = True
+        self._redis_enabled = False
+
+    def _from_redis(self, key: Hashable) -> SearchCacheEntry | None:
+        if not self._redis_enabled or self._redis is None:
+            return None
+        try:
+            payload = self._redis.get(self._redis_key(key))
+        except RedisError as exc:
+            self._disable_redis("Redis search cache read failed", exc=exc)
+            return None
+        if payload is None:
+            return None
+        try:
+            data = json.loads(payload.decode("utf-8"))
+            return SearchCacheEntry(
+                hits=data["hits"],
+                debug=data.get("debug", []),
+                bucket=data["bucket"],
+                search_id=data["search_id"],
+                timestamp=data["timestamp"],
+            )
+        except (KeyError, json.JSONDecodeError) as exc:
+            logger.debug("Invalid entry in Redis search cache", exc_info=exc)
+            return None
+
+    def _store_redis(self, key: Hashable, entry: SearchCacheEntry) -> None:
+        if not self._redis_enabled or self._redis is None:
+            return
+        payload = json.dumps(
+            {
+                "hits": entry.hits,
+                "debug": entry.debug,
+                "bucket": entry.bucket,
+                "search_id": entry.search_id,
+                "timestamp": entry.timestamp,
+            }
+        ).encode("utf-8")
+        try:
+            self._redis.set(self._redis_key(key), payload, ex=self._ttl)
+        except RedisError as exc:
+            self._disable_redis("Redis search cache write failed", exc=exc)
+
+    def get(self, key: Hashable) -> SearchCacheEntry | None:
+        entry = self._from_redis(key)
+        if entry is not None:
+            return entry
+
         now = self._time()
         with self._lock:
             entry = self._store.get(key)
@@ -99,6 +224,7 @@ class SearchCache:
         )
         with self._lock:
             self._store[key] = entry
+        self._store_redis(key, entry)
 
     def clear(self) -> None:
         with self._lock:

--- a/server/app/services/rate_limit.py
+++ b/server/app/services/rate_limit.py
@@ -2,12 +2,23 @@
 
 from __future__ import annotations
 
+import logging
 import threading
 import time
 from dataclasses import dataclass
-from typing import Callable
+from typing import Any, Callable
 
 from fastapi import HTTPException
+
+try:  # pragma: no cover - optional dependency
+    from redis import Redis
+    from redis.exceptions import RedisError
+except ModuleNotFoundError:  # pragma: no cover - fallback for tests
+    from app.utils.redis_client import RedisError
+
+    Redis = Any  # type: ignore[assignment]
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -17,20 +28,48 @@ class _Bucket:
 
 
 class RateLimiter:
-    """Simple in-memory rate limiter with per-minute buckets."""
+    """Rate limiter supporting shared Redis state with in-memory fallback."""
 
     def __init__(
         self,
         limit_per_minute: int,
         *,
         time_func: Callable[[], float] | None = None,
+        redis_client: Redis | None = None,
     ) -> None:
         self._limit = limit_per_minute
         self._time = time_func or time.time
         self._lock = threading.Lock()
         self._buckets: dict[str, _Bucket] = {}
+        self._redis = redis_client
+        self._redis_enabled = redis_client is not None
+        self._redis_warned = False
+
+    def _disable_redis(self, message: str, *, exc: Exception | None = None) -> None:
+        if not self._redis_warned:
+            logger.warning("%s; falling back to local rate limiting", message, exc_info=exc)
+            self._redis_warned = True
+        self._redis_enabled = False
+
+    def _check_redis(self, key: str) -> bool:
+        if not self._redis_enabled or self._redis is None:
+            return False
+        redis_key = f"rate-limit:{key}"
+        try:
+            count = self._redis.incr(redis_key)
+            if count == 1:
+                self._redis.expire(redis_key, 60)
+            if count > self._limit:
+                raise HTTPException(status_code=429, detail="rate limit exceeded")
+            return True
+        except RedisError as exc:
+            self._disable_redis("Redis rate limiter failed", exc=exc)
+            return False
 
     def check(self, key: str) -> None:
+        if self._check_redis(key):
+            return
+
         minute = int(self._time() // 60)
         with self._lock:
             bucket = self._buckets.get(key)

--- a/server/app/utils/redis_client.py
+++ b/server/app/utils/redis_client.py
@@ -1,0 +1,80 @@
+"""Redis client helpers for optional distributed caching support."""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+
+try:  # pragma: no cover - optional dependency branch
+    from redis import Redis
+    from redis.exceptions import RedisError
+except ModuleNotFoundError:  # pragma: no cover - testing environments without redis
+    Redis = None  # type: ignore[assignment]
+
+    class RedisError(Exception):
+        """Fallback error type when redis-py is unavailable."""
+
+        pass
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_REDIS_URL = "redis://redis:6379/0"
+
+
+def create_redis_client(
+    url: str | None = None,
+    *,
+    max_retries: int = 3,
+    retry_interval_s: float = 0.5,
+) -> Redis | None:
+    """Initialise a Redis client if configuration is available.
+
+    Parameters
+    ----------
+    url:
+        Optional Redis connection URL. If omitted, the ``REDIS_URL`` environment
+        variable is consulted. When neither is present a ``None`` client is
+        returned so callers can fall back to in-memory behaviour.
+    max_retries:
+        Number of connection attempts before giving up.
+    retry_interval_s:
+        Delay between connection attempts in seconds.
+    """
+
+    if Redis is None:
+        logger.info("redis-py not installed; using in-memory services")
+        return None
+
+    redis_url = url or os.getenv("REDIS_URL", DEFAULT_REDIS_URL)
+    if not redis_url:
+        return None
+
+    client = Redis.from_url(redis_url, decode_responses=False)
+    for attempt in range(1, max_retries + 1):
+        try:
+            client.ping()
+            logger.info("Connected to Redis at %s", redis_url)
+            return client
+        except RedisError as exc:  # pragma: no cover - network failure path
+            logger.warning(
+                "Redis connection attempt %s/%s failed: %s", attempt, max_retries, exc
+            )
+            time.sleep(retry_interval_s)
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.exception("Unexpected error connecting to Redis: %s", exc)
+            break
+
+    logger.warning("Redis unavailable at %s; continuing with in-memory services", redis_url)
+    return None
+
+
+def close_redis_client(client: Redis | None) -> None:
+    """Close the provided Redis client, ignoring errors."""
+
+    if client is None or Redis is None:
+        return
+    try:
+        client.close()
+    except (RedisError, OSError):  # pragma: no cover - defensive cleanup
+        logger.debug("Failed to close Redis client", exc_info=True)

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -3,8 +3,36 @@ from __future__ import annotations
 import pytest
 from fastapi import HTTPException
 
+try:  # pragma: no cover - allows running tests without redis installed
+    from redis.exceptions import RedisError
+except ModuleNotFoundError:  # pragma: no cover - fallback for CI environments
+    from app.utils.redis_client import RedisError
+
 from app.services.cache import EmbeddingCache, SearchCache
 from app.services.rate_limit import RateLimiter
+
+
+class DummyRedis:
+    def __init__(self) -> None:
+        self.store: dict[str, bytes] = {}
+        self.expiry: dict[str, int] = {}
+
+    def get(self, key: str) -> bytes | None:
+        return self.store.get(key)
+
+    def set(self, key: str, value: bytes, ex: int | None = None) -> None:
+        self.store[key] = value
+        if ex is not None:
+            self.expiry[key] = ex
+
+    def incr(self, key: str) -> int:
+        current = int(self.store.get(key, b"0").decode("utf-8")) if key in self.store else 0
+        current += 1
+        self.store[key] = str(current).encode("utf-8")
+        return current
+
+    def expire(self, key: str, ttl: int) -> None:
+        self.expiry[key] = ttl
 
 
 class DummyProvider:
@@ -53,3 +81,66 @@ def test_rate_limiter_blocks_after_limit():
         limiter.check("tenant")
     now[0] = 61
     limiter.check("tenant")  # new window succeeds
+
+
+def test_embedding_cache_uses_redis_across_instances():
+    provider_a = DummyProvider()
+    redis = DummyRedis()
+    cache_a = EmbeddingCache(provider_a, max_size=1, redis_client=redis, ttl_seconds=30)
+
+    result = cache_a.encode("redis-shared")
+    assert provider_a.calls == 1
+
+    provider_b = DummyProvider()
+    cache_b = EmbeddingCache(provider_b, max_size=1, redis_client=redis, ttl_seconds=30)
+    cached = cache_b.encode("redis-shared")
+
+    assert cached == result
+    assert provider_b.calls == 0
+
+
+def test_search_cache_reads_from_redis():
+    redis = DummyRedis()
+    cache_a = SearchCache(30, redis_client=redis)
+    cache_key = ("tenant", "repo", "query", None, None, False, 5)
+    cache_a.set(
+        cache_key,
+        hits=[{"chunk_id": 1}],
+        debug=[{"score": 0.1}],
+        bucket="control",
+        search_id="abc123",
+    )
+
+    cache_b = SearchCache(30, redis_client=redis)
+    entry = cache_b.get(cache_key)
+
+    assert entry is not None
+    assert entry.bucket == "control"
+    assert entry.hits[0]["chunk_id"] == 1
+
+
+def test_rate_limiter_uses_redis():
+    redis = DummyRedis()
+    limiter = RateLimiter(limit_per_minute=2, redis_client=redis)
+    limiter.check("key")
+    limiter.check("key")
+    with pytest.raises(HTTPException):
+        limiter.check("key")
+    assert redis.expiry["rate-limit:key"] == 60
+
+
+def test_rate_limiter_falls_back_when_redis_fails():
+    class FailingRedis(DummyRedis):
+        def incr(self, key: str) -> int:  # type: ignore[override]
+            raise RedisError("boom")
+
+    redis = FailingRedis()
+    now = [0.0]
+
+    def fake_time() -> float:
+        return now[0]
+
+    limiter = RateLimiter(limit_per_minute=1, time_func=fake_time, redis_client=redis)
+    limiter.check("key")
+    with pytest.raises(HTTPException):
+        limiter.check("key")


### PR DESCRIPTION
## Summary
- add a Redis service to docker-compose and new configuration knobs for distributed caching
- introduce a shared Redis client with optional fallbacks and wire caches and rate limiter to use it
- expand documentation and tests to cover Redis-backed caching behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68de20f71ab0832e87363924050d7252